### PR TITLE
DT-3872

### DIFF
--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -1,5 +1,9 @@
 # Scripts for using docker hub API
 
+## clean_repositories.sh
+Cleans old tags from Docker Hub.
+
+
 ## replace_tags.sh
 This script can be used to push dummy minimal image to replace data build images between dates. [Deleting tags is too complicated](https://github.com/docker/distribution/pull/2169). Currently this script only works for opentripplanner-data-container and hsl-timetable-container images.
 

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -1,7 +1,7 @@
 # Scripts for using docker hub API
 
 ## clean_repositories.sh
-Cleans old tags from Docker Hub.
+Cleans old tags from Docker Hub. Runs for each repository named in REPOSITORIES array. Tags can be ignored (maybe prod, latest, etc..) when added to SKIP_TAGS array. Otherwise tags older than one year will be deleted unless they are the first tag for that year. Tags less than year old but more than one month are deleted if they are not the first for that month.
 
 
 ## replace_tags.sh

--- a/dockerhub/clean_repositories.sh
+++ b/dockerhub/clean_repositories.sh
@@ -7,11 +7,11 @@ REPOSITORIES=("hsldevcom/opentripplanner")
 
 
 
-# These tags or tags starting with these strings will be ignored!
-IGNORED_TAGS_ARR=("latest" "prod")
+# These tags or tags starting with these strings will be skipped!
+SKIP_TAGS=("latest" "prod")
 
 # Deletion rules:
-# 1) Tags in IGNORED_TAGS_ARR are skipped
+# 1) Tags in SKIP_TAGS are skipped
 # 2) More than one year old images will be deleted, unless they are the first tag of that year
 # 3) More than one month old images will be deleted, unless they are the first tag of that month and less than year old
 
@@ -106,7 +106,7 @@ do
       TAG=$(jq -r .name <<< "$result")
       
       # Do not process this TAG if found in the array
-      if [ $(contains "${IGNORED_TAGS_ARR[@]}" "$TAG") == "y" ]; then
+      if [ $(contains "${SKIP_TAGS[@]}" "$TAG") == "y" ]; then
         echo "      Skipping: ${TAG}"
       else
         echo "      Checking: ${TAG}"

--- a/dockerhub/clean_repositories.sh
+++ b/dockerhub/clean_repositories.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Config
+
+REPOSITORIES=("hsldevcom/opentripplanner")
+
+
+# Deletion rules:
+# 1) Tags in IGNORED_TAGS_ARR are not touched
+
+# These tags or tags starting with these strings will be ignored!
+IGNORED_TAGS_ARR=("latest" "prod")
+
+
+# Script starts
+
+
+# Helper variables
+NOW_YEAR=$(date +"%y")
+NOW_MONTH=$(date +"%-m") # without zero!
+NOW_TIME=$(date +"%s")
+# OLDER_THAN=$(expr $THRESHOLD_DAYS \* 24 \* 60 \* 60)
+JSON_HEADER="Content-Type: application/json"
+
+# Helper for logging into Docker Hub
+login_data() {
+cat <<EOF
+{
+  "username": "$DOCKER_USER",
+  "password": "$DOCKER_AUTH"
+}
+EOF
+}
+
+# Does list contain an item, e.g. contains list item
+# TODO: SKip tags starting with....
+function contains() {
+  local n=$#
+  local value=${!n}
+  for ((i=1;i < $#;i++)) {
+      if [[ ${!i} =~ $value.* ]]; then
+          echo "y"
+          return 0
+      fi
+  }
+  echo "n"
+  return 1
+}
+
+# Loop though repositories
+for NAME in "${REPOSITORIES[@]}"
+do
+  # (Re-)Login for each repository
+  # TOKEN=`curl -s -H "$JSON_HEADER" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
+  AUTH_HEADER="Authorization: JWT ${TOKEN}"
+  echo "Cleaning repository: ${NAME}"
+
+  # Get tags for a repository (paginated)
+  NEXT_URL="https://hub.docker.com/v2/repositories/${NAME}/tags/" 
+
+  # Repeat through the repository
+  while [ "$NEXT_URL" != "null" ]
+  do
+
+    # Get tags for a repository (paginated)
+    JSON_RESPONSE=`curl -s "$NEXT_URL" -X GET -H "$AUTH_HEADER" -H "$JSON_HEADER"`
+    # Extract next url
+    NEXT_URL=$(jq -r .next <<< "$JSON_RESPONSE")
+
+    # Loop through the results from current page
+    jq -c '.results[]' <<< "$JSON_RESPONSE" | while read result;
+    do
+      DELETE=false
+      TAG=$(jq -r .name <<< "$result")
+      
+      # Do not process this TAG if found in the array
+      if [ $(contains "${IGNORED_TAGS_ARR[@]}" "$TAG") == "y" ]; then
+        echo "Skipping: ${TAG}"
+      else
+        echo "Checking: ${TAG}"
+        #
+        TAG_UPDATED=$(jq -r .last_updated <<< "$result")
+        TAG_EPOCH=$(date -d "${TAG_UPDATED}" +"%s")
+        TAG_YEAR=$(date -d "${TAG_UPDATED}" +"%y")
+        TAG_MONTH=$(date -d "${TAG_UPDATED}" +"%-m")
+        TAG_DAY=$(date -d "${TAG_UPDATED}" +"%-d")       
+
+        if [ "$DELETE" == true ]; then
+          echo "Deleting: ${TAG_NAME}"
+          # TODO: ENABLE DELETION
+          ## curl "https://hub.d_remove_this_docker.com/v2/repositories/${NAME}/tags/${TAG}/" -X DELETE -H "$AUTH_HEADER"
+        fi
+
+      fi
+      sleep 1
+    done
+
+    sleep 1
+    exit 0
+
+  done
+done
+

--- a/dockerhub/clean_repositories.sh
+++ b/dockerhub/clean_repositories.sh
@@ -147,7 +147,7 @@ do
         if [ "$TAG_EPOCH" -lt "$YEAR_AGO" ] && [ "$YEAR_CHANGED" == false ]; then
           echo "        --> More than one year old"
           DELETE=true
-        elif [ "$TAG_EPOCH" -lt "$MONTH_AGO" ] && [ "$MONTH_CHANGED" == false ]; then
+        elif [ "$TAG_EPOCH" -lt "$MONTH_AGO" ] && [ "$YEAR_CHANGED" == false ] && [ "$MONTH_CHANGED" == false ]; then
           echo "        --> More than one month old"
           DELETE=true
         else

--- a/dockerhub/clean_repositories.sh
+++ b/dockerhub/clean_repositories.sh
@@ -2,27 +2,31 @@
 
 set -e
 
-# Config
-
+# Target repositories: repository is <org>/<image>
 REPOSITORIES=("hsldevcom/opentripplanner")
 
 
-# Deletion rules:
-# 1) Tags in IGNORED_TAGS_ARR are not touched
 
 # These tags or tags starting with these strings will be ignored!
 IGNORED_TAGS_ARR=("latest" "prod")
 
-
-# Script starts
+# Deletion rules:
+# 1) Tags in IGNORED_TAGS_ARR are skipped
+# 2) More than one year old images will be deleted, unless they are the first tag of that year
+# 3) More than one month old images will be deleted, unless they are the first tag of that month and less than year old
 
 
 # Helper variables
-NOW_YEAR=$(date +"%y")
-NOW_MONTH=$(date +"%-m") # without zero!
 NOW_TIME=$(date +"%s")
-# OLDER_THAN=$(expr $THRESHOLD_DAYS \* 24 \* 60 \* 60)
+ONE_MONTH=$(expr 31 \* 24 \* 60 \* 60)
+ONE_YEAR=$(expr 365 \* 24 \* 60 \* 60)
+
+MONTH_AGO=$(expr $NOW_TIME - $ONE_MONTH)
+YEAR_AGO=$(expr $NOW_TIME - $ONE_YEAR)
+
 JSON_HEADER="Content-Type: application/json"
+
+declare -a TAGS_TO_BE_DELETED=()
 
 # Helper for logging into Docker Hub
 login_data() {
@@ -34,13 +38,13 @@ cat <<EOF
 EOF
 }
 
-# Does list contain an item, e.g. contains list item
-# TODO: SKip tags starting with....
+# Does list contain an item
+# Note: example: prod will match prod and prod-yyyy-mm-dd
 function contains() {
   local n=$#
   local value=${!n}
   for ((i=1;i < $#;i++)) {
-      if [[ ${!i} =~ $value.* ]]; then
+      if [[ $value.* =~ ${!i} ]]; then
           echo "y"
           return 0
       fi
@@ -53,53 +57,128 @@ function contains() {
 for NAME in "${REPOSITORIES[@]}"
 do
   # (Re-)Login for each repository
+  # TODO: Enable authentication
   # TOKEN=`curl -s -H "$JSON_HEADER" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
   AUTH_HEADER="Authorization: JWT ${TOKEN}"
   echo "Cleaning repository: ${NAME}"
 
-  # Get tags for a repository (paginated)
-  NEXT_URL="https://hub.docker.com/v2/repositories/${NAME}/tags/" 
+  unset TAGS_TO_BE_DELETED
 
+  # Get tags for a repository (paginated)
+  URL="https://hub.docker.com/v2/repositories/${NAME}/tags/"
+  JSON_RESPONSE=`curl -s "$URL" -X GET -H "$AUTH_HEADER" -H "$JSON_HEADER"`
+  # Total count vs results on first page
+  TOTAL_COUNT=$(jq -r .count <<< "$JSON_RESPONSE")
+  RESULT_COUNT=$(jq -r '.results | length' <<< "$JSON_RESPONSE")
+  # We go from last page to first if there are more pages!
+  if [ $(jq -r .next <<< "$JSON_RESPONSE") != "null" ]; then
+    LAST_PAGE=$(expr $(expr $TOTAL_COUNT + $RESULT_COUNT - 1) / $RESULT_COUNT)
+    PREV_URL="${URL}?page=${LAST_PAGE}"
+  else
+    PREV_URL="${URL}"
+  fi
+
+  sleep 1
+
+  # We will keep track of current year and month to track changes!
+  CURRENT_YEAR=""
+  CURRENT_MONTH=""
+  MONTH_CHANGED=false
+  YEAR_CHANGED=false
+
+  echo "  Inspect:"
   # Repeat through the repository
-  while [ "$NEXT_URL" != "null" ]
+  while [ "$PREV_URL" != "null" ]
   do
+    echo "    Page: ${PREV_URL}"
 
     # Get tags for a repository (paginated)
-    JSON_RESPONSE=`curl -s "$NEXT_URL" -X GET -H "$AUTH_HEADER" -H "$JSON_HEADER"`
+    JSON_RESPONSE=`curl -s "$PREV_URL" -X GET -H "$AUTH_HEADER" -H "$JSON_HEADER"`
     # Extract next url
-    NEXT_URL=$(jq -r .next <<< "$JSON_RESPONSE")
+    PREV_URL=$(jq -r .previous <<< "$JSON_RESPONSE")
 
-    # Loop through the results from current page
-    jq -c '.results[]' <<< "$JSON_RESPONSE" | while read result;
+    # Loop through the results from current page, (no subshell)
+    while read result;
     do
       DELETE=false
+
+      # Current tag
       TAG=$(jq -r .name <<< "$result")
       
       # Do not process this TAG if found in the array
       if [ $(contains "${IGNORED_TAGS_ARR[@]}" "$TAG") == "y" ]; then
-        echo "Skipping: ${TAG}"
+        echo "      Skipping: ${TAG}"
       else
-        echo "Checking: ${TAG}"
-        #
+        echo "      Checking: ${TAG}"
+        
+        # Info about tag's date
         TAG_UPDATED=$(jq -r .last_updated <<< "$result")
         TAG_EPOCH=$(date -d "${TAG_UPDATED}" +"%s")
         TAG_YEAR=$(date -d "${TAG_UPDATED}" +"%y")
         TAG_MONTH=$(date -d "${TAG_UPDATED}" +"%-m")
-        TAG_DAY=$(date -d "${TAG_UPDATED}" +"%-d")       
 
+        # Reset change
+        YEAR_CHANGED=false
+        MONTH_CHANGED=false
+
+        # Init these variables if empty (first tag to be processed)
+        if [ -z $CURRENT_YEAR ]; then
+          CURRENT_YEAR="${TAG_YEAR}"
+          YEAR_CHANGED=true
+        fi
+        if [ -z $CURRENT_MONTH ]; then
+          CURRENT_MONTH="${TAG_MONTH}"
+          MONTH_CHANGED=true
+        fi
+
+        # Track changes in years and months
+        if [ "$CURRENT_YEAR" -ne "$TAG_YEAR" ]; then
+          CURRENT_YEAR="${TAG_YEAR}"
+          YEAR_CHANGED=true
+          # echo "Year changed!"
+        fi
+        if [ "$CURRENT_MONTH" -ne "$TAG_MONTH" ]; then
+          CURRENT_MONTH="${TAG_MONTH}"
+          MONTH_CHANGED=true
+          # echo "Month changed!"
+        fi
+
+        # Check age when not first of year or month
+        if [ "$TAG_EPOCH" -lt "$YEAR_AGO" ] && [ "$YEAR_CHANGED" == false ]; then
+          echo "        --> More than one year old"
+          DELETE=true
+        elif [ "$TAG_EPOCH" -lt "$MONTH_AGO" ] && [ "$MONTH_CHANGED" == false ]; then
+          echo "        --> More than one month old"
+          DELETE=true
+        else
+          # We do nothing for recent tags
+          DELETE=false
+        fi
+
+        # Add for deletion
         if [ "$DELETE" == true ]; then
-          echo "Deleting: ${TAG_NAME}"
-          # TODO: ENABLE DELETION
-          ## curl "https://hub.d_remove_this_docker.com/v2/repositories/${NAME}/tags/${TAG}/" -X DELETE -H "$AUTH_HEADER"
+          TAGS_TO_BE_DELETED+=("${TAG}")
         fi
 
       fi
+
       sleep 1
-    done
+    
+    done <<< $(jq -c '.results | reverse[]' <<< "$JSON_RESPONSE")
 
     sleep 1
-    exit 0
 
   done
+
+  echo "  Delete:"
+  # Delete the tags
+  for DELETE_TAG in "${TAGS_TO_BE_DELETED[@]}"
+  do
+    echo "    Deleting: ${DELETE_TAG}"
+    # TODO: ENABLE DELETION
+    # curl "https://hub.d_remove_this_docker.com/v2/repositories/${NAME}/tags/${DELETE_TAG}/" -X DELETE -H "$AUTH_HEADER"
+    sleep 1
+  done
+
 done
 

--- a/dockerhub/clean_repositories.sh
+++ b/dockerhub/clean_repositories.sh
@@ -57,8 +57,7 @@ function contains() {
 for NAME in "${REPOSITORIES[@]}"
 do
   # (Re-)Login for each repository
-  # TODO: Enable authentication
-  # TOKEN=`curl -s -H "$JSON_HEADER" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
+  TOKEN=`curl -s -H "$JSON_HEADER" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
   AUTH_HEADER="Authorization: JWT ${TOKEN}"
   echo "Cleaning repository: ${NAME}"
 


### PR DESCRIPTION
Description:

- The script uses curl to query Docker Hub API v2

- The script cleans up Docker Hub repositories listed in REPOSITORIES array.

- Tags listed in SKIP_TAGS are skipped (tag contains string in SKIP_TAGS). (latest, prod*).

- The tags are traversed in reverse order from last to first

- Tags older than one year will be deleted unless they are the first tag for that year.

- Tags older than one month (and less than one year) will be deleted unless they are the first tag for that month.

- Age is determined by the _last_updated_ timestamp. It is not based on tag names. (31 days and 365 days, not by calendar)

Notes:

- The cleanup applies to both the new and old naming convention. Is this okay?

- Production deployments won't be removed (prod-yyyy-mm-yy). Is this okay?

- I'm not sure where or how this script would actually be run so that might require some additional changes. (Access to Docker credentials, using command parameters instead of hard coded values, the script uses jq to parse JSON etc..)

- This script removes only tags so unreferenced images (untagged) will remain. I consider deleting them a new task if we wish to do so.

- **Note: The delete command is commented out and the script won't make any changes yet.**