### PR TITLE
Add GTFS route id matching tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ client.pem
 /matomo/results
 
 node_modules/
+
+# Data files
+/otp/gtfs

--- a/otp/README.md
+++ b/otp/README.md
@@ -1,0 +1,45 @@
+# OTP tools
+
+This directory contains tools to help with OTP routing service operation.
+
+## Quick example - build OTP configuration for unpreferred lines
+
+```sh
+./fetch-gtfs.sh hsl 2 dev
+./match-routes.sh gtfs/hsl-v3-dev-gtfs.zip | ./build-array.sh HSL
+```
+
+## `fetch-gtfs.sh`
+
+Fetch GTFS data packages from digitransit routing data server.
+
+**Usage:**
+
+Fetch HSL OTP2 development data:
+
+```sh
+./fetch-gtfs.sh hsl 2 dev
+```
+
+## `match-routes.sh`
+
+A tool which reads a GTFS file (.zip) as input and outputs all route ids which
+match to optional regular expressions.
+
+**Usage:**
+
+List matching route ids:
+
+```sh
+./match-routes.sh GTFS_FILE [REGEXP]
+```
+
+Build feed scoped JSON array:
+
+```sh
+./match-routes.sh GTFS_FILE | ./build-feed HSL
+```
+
+Default value for `REGEXP` is `^(21(4[3-9]|5[0-9]|6[0-5])(A|[B-Z]A).*|2321)$`.
+This expression matches to Espoo bus lines which should be avoided if reasonable
+alternate itinerary with subway exists.

--- a/otp/build-array.sh
+++ b/otp/build-array.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script reads unscoped route ids from stdin and
+# outputs a valid JSON array 
+
+FEED_SCOPE=${1:-HSL}
+
+# Check to see if a pipe exists on stdin.
+if [ -p /dev/stdin ]; then
+    echo "["
+    FIRST=1
+    # read the input line by line
+    while IFS= read -r LINE; do
+        # comma
+        if [ $FIRST -eq 0 ]; then
+            echo ","
+        else
+            FIRST=0
+        fi
+        echo -n '  "'"$FEED_SCOPE:$LINE"'"'
+    done
+    echo
+    echo "]"
+    # Or if we want to simply grab all the data, we can simply use cat instead
+    # cat
+else
+    >&2 echo "No input was found on stdin, skipping!"
+fi

--- a/otp/fetch-gtfs.sh
+++ b/otp/fetch-gtfs.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+GREEN="\e[32m"
+RED="\e[31m"
+ENDCOLOR="\e[0m"
+
+green () {
+    echo -e "$GREEN$1$ENDCOLOR"
+}
+
+errline () {
+    >&2 echo -e "$RED$1$ENDCOLOR"
+}
+
+
+# This script downloads GTFS file from digitransit.routing data
+usage () {
+    >&2 echo
+    >&2 echo "Usage:"
+    >&2 echo
+    >&2 echo "    $0 ROUTER [VERSION] [prod]"
+    >&2 echo
+    >&2 echo "ROUTER:"
+    >&2 echo "    hsl"
+    >&2 echo
+    >&2 echo "VERSION:"
+    >&2 echo "    1 or 2 (default)"
+    >&2 echo
+}
+
+errmsg () {
+    >&2 echo
+    errline "$1"
+    >&2 echo
+    exit 1
+}
+
+if [ -z "$1" ]
+then
+    usage
+    errmsg "Missing argument: router"
+fi
+
+# parse dev/prod
+API_STAGE="$3"
+HOST_API=dev-api
+if [ "$API_STAGE" = "prod" ]
+then
+    HOST_API=api
+fi
+
+# parse version (otp1/otp2)
+VERSION=${2:-2}
+if [ "$VERSION" = "1" ]
+then
+    ROUTER_VERSION=v2
+fi
+
+if [ "$VERSION" = "2" ]
+then
+    ROUTER_VERSION=v3
+fi
+
+if [ -z "$ROUTER_VERSION" ]
+then
+    usage
+    errmsg "Invalid ROUTER VERSION"
+fi
+
+if [ "$1" = "hsl" ]; then
+    ROUTER=hsl
+    GTFS_FILE=HSL-gtfs.zip
+fi
+
+if [ -z $ROUTER ]; then
+    errmsg "Router not supported: $1"
+fi
+
+# ensure download dir
+mkdir -p gtfs
+
+# download routing gtfs
+URL="https://$HOST_API.digitransit.fi/routing-data/$ROUTER_VERSION/$ROUTER/$GTFS_FILE"
+OUT_FILE="./gtfs/$ROUTER-$ROUTER_VERSION-${API_STAGE}-gtfs.zip"
+echo "Start download $URL"
+echo
+
+if ! curl -o "$OUT_FILE" "$URL"; then
+    errmsg "Error with curl download."
+    exit 1
+fi
+
+echo
+green "Download success: $OUT_FILE"
+echo

--- a/otp/match-routes.sh
+++ b/otp/match-routes.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# This script reads GTFS file as input (argument 1) and outputs route ids matching to
+# regular expression of second argument.
+
+if [ -z "$1" ]
+then
+    >&2 echo
+    >&2 echo "Usage:"
+    >&2 echo
+    >&2 echo "    $0 GTFS_FILE [REGEXP]"
+    >&2 echo
+    exit 1
+fi
+
+GTFS_INPUT=$1
+REGEXP=${2:-'^(21(4[3-9]|5[0-9]|6[0-5])(A|[B-Z]A).*|2321|7.*)$'}
+
+# create sandbox directory
+WD=$(mktemp -d -t gtfs-XXXXXX)
+ROUTE_FILE="$WD/routes.txt"
+ROUTE_ID_FILE="$WD/route-ids.txt"
+
+echo_nopipe () {
+    # test if stdout is sent to terminal
+    if [ -t 1 ]; then
+        >&2 echo "$1"
+    fi
+}
+
+# read route_ids in routes.txt from gtfs package
+echo_nopipe " 📁 Reading file: $GTFS_INPUT"
+
+unzip "$GTFS_INPUT" routes.txt -d "$WD" > /dev/null 2>&1
+tail -n +2 "$ROUTE_FILE" | cut -d, -f1 | sort | uniq > "$ROUTE_ID_FILE"
+
+ROUTE_COUNT=$(wc -l < "$ROUTE_ID_FILE")
+echo_nopipe " 💡 Number of routes found from '$GTFS_INPUT': $ROUTE_COUNT"
+echo_nopipe " 🔎 Matching against /$REGEXP/..."
+echo_nopipe 
+
+grep -E $REGEXP "$ROUTE_ID_FILE"
+
+# clean up
+rm -rf "$WD"


### PR DESCRIPTION
**Purpose**

CLI tool which assist on curating the list of unpreferred route ids configured in `routing-config.json` of OTP2.

**Quick start**

Example usage for creating a valid configuration for unpreferred routes.

```bash
# Fetch hsl gtfs data from dev-api (routing-data/v3). Downloads the package to ./gtfs/ subdirectory.
./fetch-gtfs.sh hsl 2 dev

# Match pre-defined regexp to routes inside the gtfs package and pipe list to array
# builder (with HSL as feed scope). Outputs the array to stdout.
./match-routes.sh gtfs/hsl-v3-dev-gtfs.zip | ./build-feed.sh HSL
```
